### PR TITLE
[WAL-363] fix migration error.

### DIFF
--- a/__tests__/initial.migration.test.ts
+++ b/__tests__/initial.migration.test.ts
@@ -79,8 +79,7 @@ describe('database initial migration tests', () => {
           synchronize: false,
           migrations: migrations,
           migrationsRun: true,
-          migrationsTransactionMode: "all",
-          logging: true,
+          logging: false,
           entities: Entities,
           ...connectionOverrides,
         } as DataSourceOptions)

--- a/__tests__/initial.migration.test.ts
+++ b/__tests__/initial.migration.test.ts
@@ -79,7 +79,8 @@ describe('database initial migration tests', () => {
           synchronize: false,
           migrations: migrations,
           migrationsRun: true,
-          logging: false,
+          migrationsTransactionMode: "all",
+          logging: true,
           entities: Entities,
           ...connectionOverrides,
         } as DataSourceOptions)

--- a/packages/data-store/src/entities/PreMigrationEntities.ts
+++ b/packages/data-store/src/entities/PreMigrationEntities.ts
@@ -1,5 +1,5 @@
 import { BaseEntity, Column, Entity, PrimaryColumn } from 'typeorm'
-import {Key, KeyType } from "./key";
+import {KeyType } from "./key";
 
 /**
  * This represents the private key data of keys that were stored by {@link @veramo/data-store#KeyStore} before Veramo
@@ -9,7 +9,7 @@ import {Key, KeyType } from "./key";
  * @beta This API may change without a BREAKING CHANGE notice.
  */
 @Entity('key')
-export class PreMigrationKey extends Key {
+export class PreMigrationKey extends BaseEntity {
   @PrimaryColumn()
     //@ts-ignore
   kid: string

--- a/packages/data-store/src/entities/PreMigrationEntities.ts
+++ b/packages/data-store/src/entities/PreMigrationEntities.ts
@@ -1,5 +1,5 @@
 import { BaseEntity, Column, Entity, PrimaryColumn } from 'typeorm'
-import { KeyType } from "./key";
+import {Key, KeyType } from "./key";
 
 /**
  * This represents the private key data of keys that were stored by {@link @veramo/data-store#KeyStore} before Veramo
@@ -9,7 +9,7 @@ import { KeyType } from "./key";
  * @beta This API may change without a BREAKING CHANGE notice.
  */
 @Entity('key')
-export class PreMigrationKey extends BaseEntity {
+export class PreMigrationKey extends Key {
   @PrimaryColumn()
     //@ts-ignore
   kid: string

--- a/packages/data-store/src/migrations/2.simplifyRelations.ts
+++ b/packages/data-store/src/migrations/2.simplifyRelations.ts
@@ -1,4 +1,4 @@
-import { MigrationInterface, QueryRunner, TableColumn } from 'typeorm'
+import { MigrationInterface, QueryRunner, Table, TableColumn } from 'typeorm'
 import Debug from 'debug'
 
 /**
@@ -8,19 +8,17 @@ import Debug from 'debug'
  */
 export class SimplifyRelations1447159020002 implements MigrationInterface {
   async up(queryRunner: QueryRunner): Promise<void> {
-    function getTableName(givenName: string): string {
-      return (
-        queryRunner.connection.entityMetadatas.find((meta) => meta.givenTableName === givenName)?.tableName ||
-        givenName
-      )
+    function getTable(givenName: string): Table {
+      const entityMetadatas = queryRunner.connection.entityMetadatas.find((meta) => meta.givenTableName === givenName);
+      return Table.create(entityMetadatas!, queryRunner.connection.driver);
     }
     await queryRunner.changeColumn(
-      getTableName('key'),
+      getTable('key'),
       'identifierDid',
       new TableColumn({ name: 'identifierDid', type: 'varchar', isNullable: true }),
     )
     await queryRunner.changeColumn(
-      getTableName('service'),
+        getTable('service'),
       'identifierDid',
       new TableColumn({ name: 'identifierDid', type: 'varchar', isNullable: true }),
     )

--- a/packages/data-store/src/migrations/2.simplifyRelations.ts
+++ b/packages/data-store/src/migrations/2.simplifyRelations.ts
@@ -12,16 +12,116 @@ export class SimplifyRelations1447159020002 implements MigrationInterface {
       const entityMetadatas = queryRunner.connection.entityMetadatas.find((meta) => meta.givenTableName === givenName);
       return Table.create(entityMetadatas!, queryRunner.connection.driver);
     }
-    await queryRunner.changeColumn(
-      getTable('key'),
-      'identifierDid',
-      new TableColumn({ name: 'identifierDid', type: 'varchar', isNullable: true }),
+    function getTableName(givenName: string): string {
+      return (
+          queryRunner.connection.entityMetadatas.find((meta) => meta.givenTableName === givenName)?.tableName ||
+          givenName
+      )
+    }
+
+    await queryRunner.startTransaction();
+
+    await queryRunner.createTable(
+        new Table({
+          name: getTableName('key_backup'),
+          columns: [
+            { name: 'kid', type: 'varchar', isPrimary: true },
+            { name: 'kms', type: 'varchar' },
+            { name: 'type', type: 'varchar' },
+            { name: 'publicKeyHex', type: 'varchar' },
+            { name: 'privateKeyHex', type: 'varchar', isNullable: true },
+            { name: 'meta', type: 'text', isNullable: true },
+            { name: 'identifierDid', type: 'varchar' },
+          ],
+          foreignKeys: [
+            {
+              columnNames: ['identifierDid'],
+              referencedColumnNames: ['did'],
+              referencedTableName: getTableName('identifier'),
+            },
+          ],
+        }),
+        true,
     )
-    await queryRunner.changeColumn(
-        getTable('service'),
-      'identifierDid',
-      new TableColumn({ name: 'identifierDid', type: 'varchar', isNullable: true }),
+    await queryRunner.manager.query('INSERT INTO '+getTableName('key_backup')+' SELECT * FROM '+getTableName('key')+';');
+    await queryRunner.manager.query('DROP TABLE '+getTableName('key')+';');
+    await queryRunner.createTable(
+        new Table({
+          name: getTableName('key'),
+          columns: [
+            { name: 'kid', type: 'varchar', isPrimary: true },
+            { name: 'kms', type: 'varchar' },
+            { name: 'type', type: 'varchar' },
+            { name: 'publicKeyHex', type: 'varchar' },
+            { name: 'privateKeyHex', type: 'varchar', isNullable: true },
+            { name: 'meta', type: 'text', isNullable: true },
+            { name: 'identifierDid', type: 'varchar', isNullable: true },
+          ],
+          foreignKeys: [
+            {
+              columnNames: ['identifierDid'],
+              referencedColumnNames: ['did'],
+              referencedTableName: getTableName('identifier'),
+            },
+          ],
+        }),
+        true,
     )
+    await queryRunner.manager.query('INSERT INTO '+getTableName('key')+' SELECT * FROM '+getTableName('key_backup')+';');
+    await queryRunner.manager.query('DROP TABLE '+getTableName('key_backup')+';');
+    await queryRunner.commitTransaction();
+
+    await queryRunner.startTransaction();
+
+    await queryRunner.createTable(
+        new Table({
+          name: getTableName('service_backup'),
+          columns: [
+            { name: 'id', type: 'varchar', isPrimary: true },
+            { name: 'type', type: 'varchar' },
+            { name: 'serviceEndpoint', type: 'varchar' },
+            { name: 'description', type: 'varchar', isNullable: true },
+            { name: 'identifierDid', type: 'varchar' },
+          ],
+          foreignKeys: [
+            {
+              columnNames: ['identifierDid'],
+              referencedColumnNames: ['did'],
+              referencedTableName: getTableName('identifier'),
+              onDelete: 'cascade',
+            },
+          ],
+        }),
+        true,
+    )
+    await queryRunner.manager.query('INSERT INTO '+getTableName('service_backup')+' SELECT * FROM '+getTableName('service')+';');
+    await queryRunner.manager.query('DROP TABLE '+getTableName('service')+';');
+    await queryRunner.createTable(
+        new Table({
+          name: getTableName('service'),
+          columns: [
+            { name: 'id', type: 'varchar', isPrimary: true },
+            { name: 'type', type: 'varchar' },
+            { name: 'serviceEndpoint', type: 'varchar' },
+            { name: 'description', type: 'varchar', isNullable: true },
+            { name: 'identifierDid', type: 'varchar', isNullable: true  },
+          ],
+          foreignKeys: [
+            {
+              columnNames: ['identifierDid'],
+              referencedColumnNames: ['did'],
+              referencedTableName: getTableName('identifier'),
+              onDelete: 'cascade',
+            },
+          ],
+        }),
+        true,
+    )
+    await queryRunner.manager.query('INSERT INTO '+getTableName('service')+' SELECT * FROM '+getTableName('service_backup')+';');
+    await queryRunner.manager.query('DROP TABLE '+getTableName('service_backup')+';');
+    await queryRunner.commitTransaction();
+
+
   }
 
   async down(queryRunner: QueryRunner): Promise<void> {

--- a/packages/data-store/src/migrations/4.allowNullVPIssuanceDate.ts
+++ b/packages/data-store/src/migrations/4.allowNullVPIssuanceDate.ts
@@ -1,4 +1,4 @@
-import { MigrationInterface, QueryRunner } from 'typeorm'
+import { MigrationInterface, QueryRunner, Table } from 'typeorm'
 import { Presentation } from '..'
 import Debug from 'debug'
 
@@ -16,6 +16,10 @@ export class AllowNullIssuanceDateForPresentations1637237492913 implements Migra
       givenName
     )
   }
+  async getTable(queryRunner: QueryRunner, givenName: string): Promise<Table> {
+    const entityMetadatas = queryRunner.connection.entityMetadatas.find((meta) => meta.givenTableName === givenName);
+    return Table.create(entityMetadatas!, queryRunner.connection.driver);
+  }
 
   async up(queryRunner: QueryRunner): Promise<void> {
     if (queryRunner.connection.driver.options.type === 'sqlite') {
@@ -26,9 +30,8 @@ export class AllowNullIssuanceDateForPresentations1637237492913 implements Migra
       await queryRunner.startTransaction()
     }
 
-    const tableName = this.getTableName('presentation', queryRunner)
     // update issuanceDate column
-    let table = await queryRunner.getTable(tableName)
+    let table = await this.getTable(queryRunner, 'presentation');
     const oldColumn = table?.findColumnByName('issuanceDate')!
     const newColumn = oldColumn.clone()
     newColumn.isNullable = true

--- a/packages/did-comm/src/__tests__/trust-ping-message-handler.test.ts
+++ b/packages/did-comm/src/__tests__/trust-ping-message-handler.test.ts
@@ -171,16 +171,16 @@ describe('trust-ping-message-handler', () => {
   const expectResponse = (tpid: string) => {
     // recipient sends response
     expect(DIDCommEventSniffer.onEvent).toHaveBeenCalledWith(
-      { 
-        data: `${tpid}-response`, 
-        type: 'DIDCommV2Message-sent' 
+      {
+        data: `${tpid}-response`,
+        type: 'DIDCommV2Message-sent'
       },
       expect.anything(),
     )
 
     // original sender receives response
     expect(DIDCommEventSniffer.onEvent).toHaveBeenCalledWith(
-      { 
+      {
         data: {
           message: {
             body: {},
@@ -201,16 +201,16 @@ describe('trust-ping-message-handler', () => {
   const expectPing = (tpid: string, packing: string) => {
     // recipient sends response
     expect(DIDCommEventSniffer.onEvent).toHaveBeenCalledWith(
-      { 
-        data: `${tpid}`, 
-        type: 'DIDCommV2Message-sent' 
+      {
+        data: `${tpid}`,
+        type: 'DIDCommV2Message-sent'
       },
       expect.anything(),
     )
 
     // original sender receives response
     expect(DIDCommEventSniffer.onEvent).toHaveBeenCalledWith(
-      { 
+      {
         data: {
           message: {
             body: {
@@ -242,7 +242,7 @@ describe('trust-ping-message-handler', () => {
     }}, { agent })
     expectResponse(tpid)
     expect(DIDCommEventSniffer.onEvent).toHaveBeenCalledTimes(2)
-  })
+  }, 25000)
 
   it('should pack and unpack trust ping message with none packing', async () => {
     const trustPingMessage = createTrustPingMessage(sender.did, recipient.did)
@@ -267,7 +267,7 @@ describe('trust-ping-message-handler', () => {
     expectResponse(tpid)
   })
 
-  
+
   it('should handle none-packed trust ping message sent via didcomm', async () => {
     const trustPingMessage = createTrustPingMessage(sender.did, recipient.did)
     const packedMessage = await agent.packDIDCommMessage({ packing: 'none', message: trustPingMessage})
@@ -276,16 +276,16 @@ describe('trust-ping-message-handler', () => {
 
     // recipient sends response
     expect(DIDCommEventSniffer.onEvent).toHaveBeenCalledWith(
-      { 
-        data: `${tpid}`, 
-        type: 'DIDCommV2Message-sent' 
+      {
+        data: `${tpid}`,
+        type: 'DIDCommV2Message-sent'
       },
       expect.anything(),
     )
 
     // original sender receives response
     expect(DIDCommEventSniffer.onEvent).toHaveBeenCalledWith(
-      { 
+      {
         data: {
           message: {
             body: {
@@ -305,7 +305,7 @@ describe('trust-ping-message-handler', () => {
     )
   })
 
-   
+
   it('should handle authcrypt-packed trust ping message sent via didcomm', async () => {
     const trustPingMessage = createTrustPingMessage(sender.did, recipient.did)
     const tpid = trustPingMessage.id

--- a/packages/did-provider-ion/__tests__/ion-did-provider.test.ts
+++ b/packages/did-provider-ion/__tests__/ion-did-provider.test.ts
@@ -77,7 +77,7 @@ describe('@veramo/did-provider-ion', () => {
       }
       await expect(error.message).toMatch('An operation request already exists in queue for DID')
     }
-  })
+  }, 25000)
 
   it('should add service', async () => {
     // This DID is known in ION, hence no anchoring


### PR DESCRIPTION
## What issue is this PR fixing

`While running TypeORM (SQLite) DB Migrations a console message was shown that the migrations were not successful. 
> "SimplifyRelations1447159020002" failed, error: Column "identifierDid" was not found in the "key" table.

## What is being changed
`This PR fixes this error by using the Table object instead of table name string. By not using the changeColumn function we avoid the incorrectly formed DBQuery fragment.` 

`const keys: PreMigrationKey[] = await queryRunner.manager.find(PreMigrationKey)` is also giving the error that we get when we use TableNameStrings instead of table object. Hence, the simple query was run. PreMigrationKey Entity is using the 'key' named table.

## Quality
Check all that apply:
* [X] I want these changes to be integrated
* [X] I successfully ran `yarn`, `yarn build`, `yarn test`, `yarn test:browser` locally.
* [X] I allow my PR to be updated by the reviewers (to speed up the review process).
* [ ] I added unit tests.
* [ ] I added integration tests.
* [X] I did not add automated tests because the problem occurs on runtime on some devices with particular OS versions. Hence it is not build stage testable, and I am aware that a PR without tests will likely get rejected.
